### PR TITLE
fix startup crash on L preview

### DIFF
--- a/app/src/main/java/fr/ydelouis/selfoss/sync/SyncManager.java
+++ b/app/src/main/java/fr/ydelouis/selfoss/sync/SyncManager.java
@@ -35,12 +35,12 @@ public class SyncManager {
 	}
 
 	public boolean isActive() {
-		  Account account = selfossAccount.getAccount();
-          if (account != null) {
-              return ContentResolver.isSyncActive(account, AUTHORITY);
-          } else {
-              return false;
-          }
+		Account account = selfossAccount.getAccount();
+		if (account != null) {
+			return ContentResolver.isSyncActive(account, AUTHORITY);
+		} else {
+			return false;
+		}
 	}
 
 }


### PR DESCRIPTION
Null account causes crash on startup, with Android L preview.
